### PR TITLE
fix #6: camelCased tags seem to loose their camelcasing

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function parseSVG(svg, callback) {
         explicitRoot: false,
         mergeAttrs: false,
         normalize: true,
-        normalizeTags: true,
+        normalizeTags: false,
         preserveChildrenOrder: true,
         attrNameProcessors: [utils.processAttributeName],
         validator: cleanupParsedSVGElement

--- a/test/conversion_test.js
+++ b/test/conversion_test.js
@@ -268,5 +268,16 @@ describe('svg-to-jsx', function() {
                 done();
             });
         });
+
+        it('should preserve case on tag names', function(done) {
+            var input = '<svg version="1.1"><linearGradient/></svg>';
+
+            svgToJsx(input, function(error, result) {
+                expect(error).to.be(null);
+                expect(result).to.be('<svg version="1.1">\n\t<linearGradient/>\n</svg>');
+
+                done();
+            });
+        });
     });
 });

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -90,4 +90,25 @@ describe('utils', function() {
             expect(utils.processAttributeName('data-width')).to.be('data-width');
         });
     });
+
+    context('sanitizeChildren()', function() {
+        it('should return null if called with falsy parameter', function() {
+            expect(utils.sanitizeChildren()).to.be(null);
+            expect(utils.sanitizeChildren(null)).to.be(null);
+            expect(utils.sanitizeChildren(undefined)).to.be(null);
+            expect(utils.sanitizeChildren(false)).to.be(null);
+        });
+
+        it('should not remove supported tags', function() {
+            const actual = [ { tagName: 'linearGradient' } ];
+            const expected = [ { tagName: 'linearGradient' } ];
+            expect(utils.sanitizeChildren(actual)).to.eql(expected);
+        });
+
+        it('should remove unsupported tags', function() {
+            const actual = [ { tagName: 'lineargradient' } ];
+            const expected = [];
+            expect(utils.sanitizeChildren(actual)).to.eql(expected);
+        });
+    });
 });

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -100,14 +100,14 @@ describe('utils', function() {
         });
 
         it('should not remove supported tags', function() {
-            const actual = [ { tagName: 'linearGradient' } ];
-            const expected = [ { tagName: 'linearGradient' } ];
+            var actual = [ { tagName: 'linearGradient' } ];
+            var expected = [ { tagName: 'linearGradient' } ];
             expect(utils.sanitizeChildren(actual)).to.eql(expected);
         });
 
         it('should remove unsupported tags', function() {
-            const actual = [ { tagName: 'lineargradient' } ];
-            const expected = [];
+            var actual = [ { tagName: 'lineargradient' } ];
+            var expected = [];
             expect(utils.sanitizeChildren(actual)).to.eql(expected);
         });
     });

--- a/utils.js
+++ b/utils.js
@@ -6,7 +6,7 @@ var ALLOWED_HTML_ATTRIBUTES = 'accept acceptCharset accessKey action allowFullSc
 var ALLOWED_SVG_ATTRIBUTES = 'clipPath cx cy d dx dy fill fillOpacity fontFamily fontSize fx fy gradientTransform gradientUnits markerEnd markerMid markerStart offset opacity patternContentUnits patternUnits points preserveAspectRatio r rx ry spreadMethod stopColor stopOpacity stroke strokeDasharray strokeLinecap strokeOpacity strokeWidth textAnchor transform version viewBox x1 x2 x y1 y2 y xlink:actuate xlink:arcrole xlink:href xlink:role xlink:show xlink:title xlink:type xml:base xml:lang xml:space'.split(' ');
 
 var ALLOWED_ATTRIBUTES = ALLOWED_HTML_ATTRIBUTES.concat(ALLOWED_SVG_ATTRIBUTES);
-var ALLOWED_TAGS = 'circle clipPath defs ellipse g image line linearGradient mask path pattern polygon polyline radialGradient rect stop svg text tspan'.toLowerCase().split(' ');
+var ALLOWED_TAGS = 'circle clipPath defs ellipse g image line linearGradient mask path pattern polygon polyline radialGradient rect stop svg text tspan'.split(' ');
 
 var DATA_ATTRIBUTE = /^data-/i;
 


### PR DESCRIPTION
Greetings and thanks for the lovely library.
I believe this fixes the camelcase issue.

We could better test this if we had some SVG fixtures to test against. If you are interested in having some fixtures added, I may find some time to do it. Let me know,

Thanks!

-Jared
