### PR TITLE
update 3rd party libraries to resolve security issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-    - '0.10'
+    - '6.17.1'
 install:
     - npm install
 script:

--- a/index.js
+++ b/index.js
@@ -77,7 +77,25 @@ function formatElementForXMLBuilder(element) {
     }, {});
 
     if (element.text) result['#text'] = element.text;
-    if (children && children.length) result['#list'] = children;
+
+    if (children && children.length) {
+        children.forEach(function(child) {
+            var tagName = Object.keys(child)[0];
+            var existingValue = result[tagName];
+            if (existingValue) {
+                if (Array.isArray(existingValue)) {
+                    // existing element array, push new element
+                    existingValue.push(child[tagName]);
+                } else {
+                    // create array with existing and new elements
+                    result[tagName] = [existingValue, child[tagName]];
+                }
+            } else {
+                // first child element with this tag name
+                result[tagName] = child[tagName];
+            }
+        });
+    }
 
     var wrapped = {};
     wrapped[element.tagName] = result;

--- a/package.json
+++ b/package.json
@@ -26,14 +26,14 @@
     "object-assign": "^4.0.1",
     "q": "^1.4.1",
     "xml2js": "^0.4.10",
-    "xmlbuilder": "^2.6.4",
+    "xmlbuilder": "^13.0.2",
     "yargs": "^3.21.0"
   },
   "devDependencies": {
-    "babel-eslint": "^4.0.10",
-    "eslint": "^1.2.1",
+    "babel-eslint": "^10.0.2",
+    "eslint": "^6.1.0",
     "expect.js": "^0.3.1",
-    "mocha": "^2.2.5"
+    "mocha": "^6.2.0"
   },
   "tonicExampleFilename": "example.js"
 }


### PR DESCRIPTION
- update 3rd party packages to modern versions
- update of `xmlbuilder` required changing the logic of `formatElementForXMLBuilder` to not use a `#list` decorator for the child elements.
  - The child elements are now directly added as attributes of the parent object.
- update of mocha to latest version required bumping the node version installed for travis CI builds to v6.17.1 as latest mocha uses the `const` keyword

before changes:
```
>npm audit
found 22 vulnerabilities (5 low, 1 moderate, 15 high, 1 critical) in 659 scanned packages
```

after changes:
```
>npm audit
found 0 vulnerabilities in 525 scanned packages
```