### PR TITLE
Updated dependencies to fix vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svg-to-jsx",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "SVG to JSX converter",
   "main": "index.js",
   "scripts": {
@@ -23,17 +23,17 @@
   },
   "homepage": "https://github.com/janjakubnanista/svg-to-jsx",
   "dependencies": {
-    "object-assign": "^4.0.1",
-    "q": "^1.4.1",
-    "xml2js": "^0.4.10",
-    "xmlbuilder": "^13.0.2",
-    "yargs": "^3.21.0"
+    "object-assign": "^4.1.1",
+    "q": "^1.5.1",
+    "xml2js": "^0.5.0",
+    "xmlbuilder": "^15.1.1",
+    "yargs": "^17.7.1"
   },
   "devDependencies": {
-    "babel-eslint": "^10.0.2",
-    "eslint": "^6.1.0",
+    "babel-eslint": "^10.1.0",
+    "eslint": "^8.38.0",
     "expect.js": "^0.3.1",
-    "mocha": "^6.2.0"
+    "mocha": "^10.2.0"
   },
   "tonicExampleFilename": "example.js"
 }


### PR DESCRIPTION
Updated all dependencies to the latest version to fix 2 high and 3 critical vulnerabilities. Installs correctly and all the tests pass.

npm audit report:
flat  <5.0.1
Severity: critical
flat vulnerable to Prototype Pollution - https://github.com/advisories/GHSA-2j2x-2gpw-g8fm fix available via `npm audit fix --force`
Will install mocha@10.2.0, which is a breaking change node_modules/flat
  yargs-unparser  <=1.6.3
  Depends on vulnerable versions of flat
  node_modules/yargs-unparser
    mocha  5.1.0 - 9.2.1
    Depends on vulnerable versions of minimatch
    Depends on vulnerable versions of yargs-unparser
    node_modules/mocha

minimatch  <3.0.5
Severity: high
minimatch ReDoS vulnerability - https://github.com/advisories/GHSA-f8q6-p94x-37v3 fix available via `npm audit fix --force`
Will install mocha@10.2.0, which is a breaking change node_modules/mocha/node_modules/minimatch

xml2js  <0.5.0
Severity: high
xml2js is vulnerable to prototype pollution  - https://github.com/advisories/GHSA-776f-qx25-q3cc fix available via `npm audit fix --force`
Will install xml2js@0.5.0, which is a breaking change node_modules/xml2js

5 vulnerabilities (2 high, 3 critical)